### PR TITLE
Fix intermission screen split data time diff

### DIFF
--- a/prboom2/src/dsda/intermission_display.c
+++ b/prboom2/src/dsda/intermission_display.c
@@ -80,7 +80,7 @@ static void dsda_UpdateIntermissionTime(dsda_split_t* split) {
     if (diff >= 2100) {
       snprintf(
         delta, sizeof(delta),
-        " (%s%d:%04.2f)",
+        " (%s%d:%05.2f)",
         sign, diff / 35 / 60, (float)(diff % (60 * 35)) / 35
       );
     }


### PR DESCRIPTION
If the number of minutes is less than 10 we should have a leading '0'.

Fixes #136